### PR TITLE
feat(keymaps): add optional filename-preserving upload variants for c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ A simple Neovim plugin to upload files, yanks, and selections to
 ## Obligatory Demos
 
 - Uploading current opened file:
-![demo-file](doc/demo_file.gif)
+  ![demo-file](doc/demo_file.gif)
 
 - Uploading visual selection:
-![demo-visual](doc/demo_visual_selection.gif)
+  ![demo-visual](doc/demo_visual_selection.gif)
 
 - Uploading last yanked/deleted text:
-![demo-yank](doc/demo_yank.gif)
+  ![demo-yank](doc/demo_yank.gif)
 
 - Uploading a file selected in `oil.nvim`:
-![demo-oil](doc/demo_oil.gif)
+  ![demo-oil](doc/demo_oil.gif)
 
 - Uploading an image selected in `oil.nvim`:
-![demo-oil](doc/demo_oil_image.gif)
+  ![demo-oil](doc/demo_oil_image.gif)
 
 ## Installation
 
@@ -40,37 +40,45 @@ require('lazy').setup({
 
 ## Usage
 
-By default, the following keymaps are available:
+By default, the following keybindings are available:
 
-- `<leader>0f` - Upload the current file
-- `<leader>0s` - Upload the current visual selection
-- `<leader>0y` - Upload the last yank or delete content 
-- `<leader>0o` - Upload a file selected in `oil.nvim`
+- `<leader>0f` — Upload the current file
+- `<leader>0F` — Upload the current file (preserving original filename in URL)
+- `<leader>0s` — Upload the current visual selection
+- `<leader>0y` — Upload the last yank or delete content
+- `<leader>0o` — Upload the file under cursor in `oil.nvim`
+- `<leader>0O` — Upload the `oil.nvim` file (preserving original filename in URL)
 
-If `use_default_keymaps = false`, you can define your own mappings, like:
+These can be disabled by setting `use_default_keymaps = false` in the plugin setup.
+
+If you'd prefer to use your own mappings, here's how you can set them up:
 
 ```lua
 vim.keymap.set('n', '<leader>uf', require("nvim-0x0").upload_current_file, { desc = "Upload current file" })
+vim.keymap.set('n', '<leader>uF', function()
+  require("nvim-0x0").upload_current_file({ append_filename = true })
+end, { desc = "Upload current file (preserve filename)" })
 vim.keymap.set('v', '<leader>us', require("nvim-0x0").upload_selection, { desc = "Upload selection" })
 vim.keymap.set('n', '<leader>uy', require("nvim-0x0").upload_yank, { desc = "Upload yank" })
 vim.keymap.set('n', '<leader>uo', require("nvim-0x0").upload_oil_file, { desc = "Upload oil.nvim file" })
+vim.keymap.set('n', '<leader>uO', function()
+  require("nvim-0x0").upload_oil_file({ append_filename = true })
+end, { desc = "Upload oil.nvim file (preserve filename)" })
 ```
 
 If you'd like to host your own instance of 0x0, set `base_url =
 "https://0x0.st/"`.
 
-
 ## Contributing
 
-Contributions are welcome! Please follow these steps:  
+Contributions are welcome! Please follow these steps:
 
-1. Fork the repository.  
-2. Create a new branch for your changes.  
-3. Make your modifications and ensure they follow the project's style.  
-4. Submit a pull request with a clear description of your changes.  
+1. Fork the repository.
+2. Create a new branch for your changes.
+3. Make your modifications and ensure they follow the project's style.
+4. Submit a pull request with a clear description of your changes.
 
 ## License
 
 This project is licensed under the GPL-2.0. See the [LICENSE](LICENSE) file for
 details.
-


### PR DESCRIPTION
…urrent and oil files

- Added `<leader>0F` to upload the current file with the original filename in the URL

- Added `<leader>0O` to upload oil.nvim file with filename in the URL

- Made `upload_files` support an `append_filename` option

- Updated README with new keymaps and usage example

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/97bfb4f7-e69a-4a32-85a2-146344229b52" />
